### PR TITLE
added composer configuration to search in repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ With Akeneo 1.3 or 1.4, you need to install this Bundle (https://github.com/aken
 
 Install module by Composer as follows:
 
+Configure Composer to search for this repository
+
+```shell
+composer config repositories.agencednd/module-pimgento vcs https://github.com/Agence-DnD/PIMGento-2
+```
+Require this repository in Composer
 ```shell
 composer require agencednd/module-pimgento
 ```


### PR DESCRIPTION
Default instalation is not set up to search GitHub VCS. To install this repo Composer must be told where to find it first as it is not in `Composer` source type `https://repo.magento.com/`

If it is not first designated, user will get generic error:
```
 [InvalidArgumentException]                                                                                                                             
  Could not find package agencednd/module-pimgento at any version for your minimum-stability (alpha). Check the package spelling or your minimum-stability
```