### PR TITLE
#75 fix load model import.

### DIFF
--- a/Import/Model/Import.php
+++ b/Import/Model/Import.php
@@ -40,7 +40,17 @@ class Import extends DataObject
             throw new Exception(__('Import code is empty'));
         }
 
-        $import = $this->_importCollection->addCodeFilter($code)->loadImport()->getFirstItem();
+        $collection = $this->_importCollection->addCodeFilter($code)->loadImport();
+        $import = $collection->getFirstItem();
+
+        if($import->getCode()!=$code) {
+            foreach ($collection->getItems() as $item) {
+                if ($item->getCode() == $code) {
+                    $import = $item;
+                    break;
+                }
+            }
+        }
 
         if (!$import->hasData()) {
             throw new Exception(__('Import %1 not found', $code));


### PR DESCRIPTION


It does not work correctly loading entity model for importing sequential or loop.
Load method ($this->_import->load($code)) returns the first entry collection.

Example code:

```
 $import = [
            ['code'=>'category','file'=>'category.csv'],
            ['code'=>'family','file'=>'family.csv'],
            ['code'=>'attribute','file'=>'attribute.csv'],
            ['code'=>'option','file'=>'option.csv'],

        ];

        foreach ($import as $item) {
            $import = $this->_import->load($item['code']);
            $import->setCode($item['code'])->setFile($item['file'])->setStep(0);
            echo 'Code: ' . $code . ' Class -' . get_class($import) . '<br>';
        }
```

Result:
Code: category Class -Pimgento\Category\Model\Factory\Import
Code: family Class -Pimgento\Category\Model\Factory\Import
Code: attribute Class -Pimgento\Category\Model\Factory\Import
Code: option Class -Pimgento\Category\Model\Factory\Import
