### PR TITLE
Loosen PHP version constraints

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "agencednd/module-pimgento",
   "description": "Module Pimgento for Magento 2",
   "require": {
-    "php": "~5.5.0|~5.6.0|~7.0.0",
+    "php": "^5.5|^7.0",
     "magento/framework": "*",
     "magento/module-backend": "*",
     "magento/module-catalog": "*",


### PR DESCRIPTION
PHP use semantic versioning, which means they aim not to introduce BC breaks in minor versions. I.e., if your package works on PHP 7.0, it almost certainly works on 7.1.

PHP 7.1 has now been released but the constraints in pimgento's composer.json prevent projects from installing on PHP 7.1.