### PR TITLE
Integrity constraint violation when importing a in a shop with multiple store views

### DIFF
--- a/Import/Helper/UrlRewrite.php
+++ b/Import/Helper/UrlRewrite.php
@@ -114,6 +114,7 @@ class UrlRewrite extends AbstractHelper
                 't._entity_id = u.entity_id 
                 AND u.entity_type = "' . $code . '" 
                 AND u.redirect_type = 0
+                AND u.store_id = ' . $storeId . '
                 AND u.target_path = ' . $targetPathExpr,
                 array()
             )


### PR DESCRIPTION
Our first installation was a M2 installation with one view. After adding a new store view/front, the product import failed (see [error.txt](https://github.com/Agence-DnD/PIMGento-2/files/763652/error.txt)).
After debugging, I found out that the query responsible for generating the url_rewrite records was missing a join on store_id. At least, i fixed that in our code and now the error is gone, and the same product is added twice to the url_rewrite table with store_id 1 and 2.

