### PR TITLE
Performance improvements in configurable product imports & Attribute Option values

### DIFF
--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -631,7 +631,7 @@ class Import extends Factory
                     ->where('_children IS NOT NULL')
             );
 
-            $valuesSuperAttribute = [];
+            $stepSize = 500;
             $valuesLabels = [];
             $valuesRelations = [];
             $valuesSuperLink = [];
@@ -706,36 +706,35 @@ class Import extends Factory
                                 'parent_id' => $row['_entity_id'],
                                 'child_id' => $childId,
                             );
-//                            $connection->insertOnDuplicate(
-//                                $connection->getTableName('catalog_product_relation'), $values, array()
-//                            );
 
                             /* catalog_product_super_link */
                             $valuesSuperLink[] = array(
                                 'product_id' => $childId,
                                 'parent_id' => $row['_entity_id'],
                             );
-//                            $connection->insertOnDuplicate(
-//                                $connection->getTableName('catalog_product_super_link'), $values, array()
-//                            );
                         }
                     }
 
 
-                    if (count($valuesSuperLink)  > 500) {
+                    if (count($valuesSuperLink)  > $stepSize) {
                         $connection->insertOnDuplicate(
-                            $connection->getTableName('catalog_product_super_attribute_label'), $valuesLabels, array()
+                            $connection->getTableName('catalog_product_super_attribute_label'),
+                            $valuesLabels,
+                            array()
                         );
 
                         $connection->insertOnDuplicate(
-                            $connection->getTableName('catalog_product_relation'), $valuesRelations, array()
+                            $connection->getTableName('catalog_product_relation'),
+                            $valuesRelations,
+                            array()
                         );
                         $connection->insertOnDuplicate(
-                            $connection->getTableName('catalog_product_super_link'), $valuesSuperLink, array()
+                            $connection->getTableName('catalog_product_super_link'),
+                            $valuesSuperLink,
+                            array()
                         );
 
 
-                        $valuesSuperAttribute = [];
                         $valuesLabels = [];
                         $valuesRelations = [];
                         $valuesSuperLink = [];
@@ -744,16 +743,21 @@ class Import extends Factory
             }
 
             if (count($valuesSuperLink)  > 0) {
-
                 $connection->insertOnDuplicate(
-                    $connection->getTableName('catalog_product_super_attribute_label'), $valuesLabels, array()
+                    $connection->getTableName('catalog_product_super_attribute_label'),
+                    $valuesLabels,
+                    array()
                 );
 
                 $connection->insertOnDuplicate(
-                    $connection->getTableName('catalog_product_relation'), $valuesRelations, array()
+                    $connection->getTableName('catalog_product_relation'),
+                    $valuesRelations,
+                    array()
                 );
                 $connection->insertOnDuplicate(
-                    $connection->getTableName('catalog_product_super_link'), $valuesSuperLink, array()
+                    $connection->getTableName('catalog_product_super_link'),
+                    $valuesSuperLink,
+                    array()
                 );
             }
         }

--- a/Variant/Model/Factory/Import.php
+++ b/Variant/Model/Factory/Import.php
@@ -148,15 +148,19 @@ class Import extends Factory
 
         $columns = array_keys($connection->describeTable($tmpTable));
 
+        $values = [];
+        $i = 0;
+        $keys = [];
         while (($row = $variant->fetch())) {
 
-            $values = array();
+
+            $values[$i] = [];
 
             foreach ($columns as $column) {
 
                 if ($connection->tableColumnExists($variantTable, $this->_columnName($column))) {
 
-                    $values[$this->_columnName($column)] = $row[$column];
+                    $values[$i][$this->_columnName($column)] = $row[$column];
 
                     if ($column == 'axis') {
                         $axisAttributes = explode(',', $row['axis']);
@@ -169,15 +173,29 @@ class Import extends Factory
                             }
                         }
 
-                        $values[$column] = join(',', $axis);
+                        $values[$i][$column] = join(',', $axis);
                     }
 
+                    $keys = array_keys($values[$i]);
                 }
-
             }
+            $i++;
 
+            /**
+             * Write 500 values at a time.
+             */
+            if (count($values) > 500) {
+                $connection->insertOnDuplicate(
+                    $variantTable, $values, $keys
+                );
+                $values = [];
+                $i = 0;
+            }
+        }
+
+        if (count($values) > 0) {
             $connection->insertOnDuplicate(
-                $variantTable, $values, array_keys($values)
+                $variantTable, $values, $keys
             );
         }
     }

--- a/Variant/Model/Factory/Import.php
+++ b/Variant/Model/Factory/Import.php
@@ -185,18 +185,14 @@ class Import extends Factory
              * Write 500 values at a time.
              */
             if (count($values) > 500) {
-                $connection->insertOnDuplicate(
-                    $variantTable, $values, $keys
-                );
+                $connection->insertOnDuplicate($variantTable, $values, $keys);
                 $values = [];
                 $i = 0;
             }
         }
 
         if (count($values) > 0) {
-            $connection->insertOnDuplicate(
-                $variantTable, $values, $keys
-            );
+            $connection->insertOnDuplicate($variantTable, $values, $keys);
         }
     }
 


### PR DESCRIPTION
Hi, 

This is a continuation of this pull request : https://github.com/Agence-DnD/PIMGento-2/pull/96

* Improved performance on variant import (takes 3 times less time)
* Improved performance when linking simple products to configurable. (On a catalog with 2 simple 1 configurable it cuts in half import time)
* Improved performance for matching product option values. The updateOption is 4 to 5 times faster working with attribute with options. 

Globally we were able to cut by 4 the import time.

Regards,