### PR TITLE
Set area code to admin in import command

### DIFF
--- a/Import/Console/Command/PimgentoImportCommand.php
+++ b/Import/Console/Command/PimgentoImportCommand.php
@@ -2,6 +2,7 @@
 
 namespace Pimgento\Import\Console\Command;
 
+use \Magento\Framework\App\State;
 use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputInterface;
 use \Symfony\Component\Console\Output\OutputInterface;
@@ -22,15 +23,22 @@ class PimgentoImportCommand extends Command
     protected $_import;
 
     /**
+     * @var \Magento\Framework\App\State
+     */
+    protected $_appState;
+
+    /**
      * PimgentoImportCommand constructor.
      *
      * @param \Pimgento\Import\Model\Import $import
+     * @param \Magento\Framework\App\State $appState
      * @param null $name
      */
-    public function __construct(ImportModel $import, $name = null)
+    public function __construct(ImportModel $import, State $appState, $name = null)
     {
         parent::__construct($name);
         $this->_import = $import;
+        $this->_appState = $appState;
     }
 
     /**
@@ -49,6 +57,7 @@ class PimgentoImportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->_appState->setAreaCode('admin');
         $code = $input->getOption(self::IMPORT_CODE);
         $file = $input->getOption(self::IMPORT_FILE);
 

--- a/Import/Console/Command/PimgentoImportCommand.php
+++ b/Import/Console/Command/PimgentoImportCommand.php
@@ -2,6 +2,7 @@
 
 namespace Pimgento\Import\Console\Command;
 
+use \Magento\Framework\App\Area;
 use \Magento\Framework\App\State;
 use \Symfony\Component\Console\Command\Command;
 use \Symfony\Component\Console\Input\InputInterface;
@@ -57,7 +58,7 @@ class PimgentoImportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->_appState->setAreaCode('admin');
+        $this->_appState->setAreaCode(Area::AREA_ADMINHTML);
         $code = $input->getOption(self::IMPORT_CODE);
         $file = $input->getOption(self::IMPORT_FILE);
 


### PR DESCRIPTION
Fixes #99.

Set the area code to `admin` when executing the import command. After some feedback from @spipu it seems better to set the area code in the whole command instead of setting it in specific classes.

Alan Storm has written a great article about this subject:
[Magento 2: Fixing Area code Not Set Exceptions](http://magento-quickies.alanstorm.com/post/142652104930/magento-2-fixing-area-code-not-set-exceptions)