### PR TITLE
Fix situations in cli where area code is already set

### DIFF
--- a/Import/Console/Command/PimgentoImportCommand.php
+++ b/Import/Console/Command/PimgentoImportCommand.php
@@ -58,8 +58,10 @@ class PimgentoImportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        if (!$this->_appState->getAreaCode()) {
+        try {
 	        $this->_appState->setAreaCode(Area::AREA_ADMINHTML);
+        } catch (\Magento\Framework\Exception\LocalizedException $e) {
+            $output->writeln('Area code already set');
         }
 
         $code = $input->getOption(self::IMPORT_CODE);

--- a/Import/Console/Command/PimgentoImportCommand.php
+++ b/Import/Console/Command/PimgentoImportCommand.php
@@ -59,7 +59,7 @@ class PimgentoImportCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         try {
-	        $this->_appState->setAreaCode(Area::AREA_ADMINHTML);
+            $this->_appState->setAreaCode(Area::AREA_ADMINHTML);
         } catch (\Magento\Framework\Exception\LocalizedException $e) {
             $output->writeln('Area code already set');
         }

--- a/Import/Console/Command/PimgentoImportCommand.php
+++ b/Import/Console/Command/PimgentoImportCommand.php
@@ -58,7 +58,10 @@ class PimgentoImportCommand extends Command
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $this->_appState->setAreaCode(Area::AREA_ADMINHTML);
+        if (!$this->_appState->getAreaCode()) {
+	        $this->_appState->setAreaCode(Area::AREA_ADMINHTML);
+        }
+
         $code = $input->getOption(self::IMPORT_CODE);
         $file = $input->getOption(self::IMPORT_FILE);
 


### PR DESCRIPTION
Someone was [experiencing problems](https://github.com/Agence-DnD/PIMGento-2/commit/fc4be94f8cf4b381ba1d451f8f4258dafa05c9c7#commitcomment-22414167) in the latest release when using the cli to run the importer. 

It's unclear what the real cause is, but adding a try/catch block shouldn't do any harm.