### PR TITLE
Fix issue with multiple store views with different languages for 1 store

### DIFF
--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -592,6 +592,14 @@ class Import extends Factory
                         if (!isset($values[$store['store_id']])) {
                             $values[$store['store_id']] = array();
                         }
+                        // Fix issue with multiple languages and rewrite of language for all the store views
+                        if(count($affected) > 1 && strpos($columnPrefix, $store['lang']) === false){
+                            continue;
+                        }
+                        // Check if value is already set and continue when value exists
+                        if (isset($values[$store['store_id']][$columnPrefix])) {
+                            continue;
+                        }
                         $values[$store['store_id']][$columnPrefix] = $column;
                     }
                 }


### PR DESCRIPTION
Fix issue with multiple store views and translations for the different store views. In the current situation the last language that is handle in the foreach loop is rewriting the language translation for all the different languages. The fix checks if there are multiple languages set for the store and checks if the language is correct for the current language. So all the translations will be correct for the different store view attributes.