### PR TITLE
Fix bug when channel is defined

### DIFF
--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -196,10 +196,10 @@ class Import extends Factory
             $matches = unserialize($matches);
             if (is_array($matches)) {
                 $stores = array_merge(
-                    $this->_helperConfig->getStores(array('lang')), // en_US
-                    $this->_helperConfig->getStores(array('lang', 'channel_code')), // en_US-channel
+                    $this->_helperConfig->getStores(array('lang')), // en_US                    
                     $this->_helperConfig->getStores(array('channel_code')), // channel
                     $this->_helperConfig->getStores(array('currency')), // USD
+                    $this->_helperConfig->getStores(array('lang', 'channel_code')), // en_US-channel
                     $this->_helperConfig->getStores(array('channel_code', 'currency')), // channel-USD
                     $this->_helperConfig->getStores(array('lang', 'channel_code', 'currency')) // en_US-channel-USD
                 );
@@ -264,10 +264,10 @@ class Import extends Factory
                 if (is_array($additional)) {
 
                     $stores = array_merge(
-                        $this->_helperConfig->getStores(array('lang')), // en_US
-                        $this->_helperConfig->getStores(array('lang', 'channel_code')), // en_US-channel
+                        $this->_helperConfig->getStores(array('lang')), // en_US                        
                         $this->_helperConfig->getStores(array('channel_code')), // channel
                         $this->_helperConfig->getStores(array('currency')), // USD
+                        $this->_helperConfig->getStores(array('lang', 'channel_code')), // en_US-channel
                         $this->_helperConfig->getStores(array('channel_code', 'currency')), // channel-USD
                         $this->_helperConfig->getStores(array('lang', 'channel_code', 'currency')) // en_US-channel-USD
                     );
@@ -528,9 +528,9 @@ class Import extends Factory
 
         $stores = array_merge(
             $this->_helperConfig->getStores(array('lang')), // en_US
-            $this->_helperConfig->getStores(array('lang', 'channel_code')), // en_US-channel
             $this->_helperConfig->getStores(array('channel_code')), // channel
             $this->_helperConfig->getStores(array('currency')), // USD
+            $this->_helperConfig->getStores(array('lang', 'channel_code')), // en_US-channel
             $this->_helperConfig->getStores(array('channel_code', 'currency')), // channel-USD
             $this->_helperConfig->getStores(array('lang', 'channel_code', 'currency')) // en_US-channel-USD
         );


### PR DESCRIPTION
When channel is defined, preg_match('/' . $suffix . '$/', $column) return value in both case lang+channel and channel.