### PR TITLE
Fix bug when channel is defined

### DIFF
--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -587,7 +587,7 @@ class Import extends Factory
             $columnPrefix = reset($columnPrefix);
 
             foreach ($stores as $suffix => $affected) {
-                if (preg_match('/' . $suffix . '$/', $column)) {
+                if (preg_match('/^' . $columnPrefix . '-' . $suffix . '$/', $column)) {
                     foreach ($affected as $store) {
                         if (!isset($values[$store['store_id']])) {
                             $values[$store['store_id']] = array();


### PR DESCRIPTION
If column description-en_US-ecommerce exists, preg_match('/' . $suffix . '$/', $column) will return value if $column equals en_US-ecommerce or ecommerce. So all data will be overriten by the last language. Replace by testing the entire column name.