### PR TITLE
Fix for empty select field values within import files

### DIFF
--- a/Entities/Model/ResourceModel/Entities.php
+++ b/Entities/Model/ResourceModel/Entities.php
@@ -388,9 +388,6 @@ class Entities extends AbstractDb
                                 'value'          => $value
                             )
                         );
-                    if ($connection->tableColumnExists($tableName, $value)) {
-                        $select->where('TRIM(`' . $value . '`) <> ?', new Expr('""'));
-                    }
 
                     $insert = $connection->insertFromSelect(
                         $select,

--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -835,8 +835,7 @@ class Import extends Factory
                     'FIND_IN_SET(`c`.`code`, `p`.`categories`) AND `c`.`import` = "category"',
                     array(
                         'category_id' => 'c.entity_id',
-                        'product_id'  => 'p._entity_id',
-                        'position'    => new Expr(1)
+                        'product_id'  => 'p._entity_id'
                     )
                 )
                 ->joinInner(
@@ -849,7 +848,7 @@ class Import extends Factory
                 $connection->insertFromSelect(
                     $select,
                     $connection->getTableName('catalog_category_product'),
-                    array('category_id', 'product_id', 'position'),
+                    array('category_id', 'product_id'),
                     1
                 )
             );


### PR DESCRIPTION
By removing this WHERE condition for generated SQL queries to import data from previously created tmp table, pimgento is now able to import empty select field values from csv files too.