### PR TITLE
Convert all getTableName methods to fix prefixed tables

### DIFF
--- a/Attribute/Model/Factory/Import.php
+++ b/Attribute/Model/Factory/Import.php
@@ -122,7 +122,8 @@ class Import extends Factory
      */
     public function matchEntity()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
 
         $select = $connection->select()
             ->from(
@@ -137,7 +138,7 @@ class Import extends Factory
 
         $connection->query(
             $connection->insertFromSelect(
-                $select,  $connection->getTableName('pimgento_entities'), array('import', 'code', 'entity_id'), 2
+                $select,  $resource->getTable('pimgento_entities'), array('import', 'code', 'entity_id'), 2
             )
         );
 
@@ -180,7 +181,8 @@ class Import extends Factory
      */
     public function matchFamily()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $connection->addColumn($tmpTable, '_attribute_set_id', 'VARCHAR(255) NULL');
@@ -190,7 +192,7 @@ class Import extends Factory
 
         $familyCodes = $connection->fetchPairs(
             $connection->select()
-                ->from($connection->getTableName('pimgento_entities'), array('code', 'entity_id'))
+                ->from($resource->getTable('pimgento_entities'), array('code', 'entity_id'))
                 ->where('import = ?', 'family')
         );
 
@@ -221,7 +223,8 @@ class Import extends Factory
     public function addAttributes()
     {
         $columns = $this->_helperType->getSpecificColumns();
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $import = $connection->select()->from($tmpTable);
@@ -236,14 +239,14 @@ class Import extends Factory
                 'attribute_code' => $row['code'],
             );
             $connection->insertOnDuplicate(
-                $connection->getTableName('eav_attribute'), $values, array_keys($values)
+                $resource->getTable('eav_attribute'), $values, array_keys($values)
             );
 
             $values = array(
                 'attribute_id' => $row['_entity_id'],
             );
             $connection->insertOnDuplicate(
-                $connection->getTableName('catalog_eav_attribute'), $values, array_keys($values)
+                $resource->getTable('catalog_eav_attribute'), $values, array_keys($values)
             );
 
             /* Retrieve default admin label */
@@ -361,7 +364,7 @@ class Import extends Factory
 
                         $exists = $connection->fetchOne(
                             $connection->select()
-                                ->from($connection->getTableName('eav_attribute_label'))
+                                ->from($resource->getTable('eav_attribute_label'))
                                 ->where('attribute_id = ?', $row['_entity_id'])
                                 ->where('store_id = ?', $store['store_id'])
                         );
@@ -374,14 +377,14 @@ class Import extends Factory
                                 'attribute_id = ?' => $row['_entity_id'],
                                 'store_id = ?' => $store['store_id']
                             );
-                            $connection->update($connection->getTableName('eav_attribute_label'), $values, $where);
+                            $connection->update($resource->getTable('eav_attribute_label'), $values, $where);
                         } else {
                             $values = array(
                                 'attribute_id' => $row['_entity_id'],
                                 'store_id' => $store['store_id'],
                                 'value' => $row['label-' . $lang]
                             );
-                            $connection->insert($connection->getTableName('eav_attribute_label'), $values);
+                            $connection->insert($resource->getTable('eav_attribute_label'), $values);
                         }
                     }
                 }

--- a/Category/Model/Factory/Import.php
+++ b/Category/Model/Factory/Import.php
@@ -252,22 +252,23 @@ class Import extends Factory
      */
     public function createEntities()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
-        if ($connection->isTableExists($connection->getTableName('sequence_catalog_category'))) {
+        if ($connection->isTableExists($resource->getTable('sequence_catalog_category'))) {
             $values = array(
                 'sequence_value' => '_entity_id',
             );
             $parents = $connection->select()->from($tmpTable, $values);
             $connection->query(
                 $connection->insertFromSelect(
-                    $parents, $connection->getTableName('sequence_catalog_category'), array_keys($values), 1
+                    $parents, $resource->getTable('sequence_catalog_category'), array_keys($values), 1
                 )
             );
         }
 
-        $table = $connection->getTableName('catalog_category_entity');
+        $table = $resource->getTable('catalog_category_entity');
 
         $values = array(
             'entity_id'        => '_entity_id',
@@ -312,7 +313,8 @@ class Import extends Factory
      */
     public function setValues()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $values = array(
@@ -323,7 +325,7 @@ class Import extends Factory
         );
 
         $this->_entities->setValues(
-            $this->getCode(), $connection->getTableName('catalog_category_entity'), $values, 3, 0, 2
+            $this->getCode(), $resource->getTable('catalog_category_entity'), $values, 3, 0, 2
         );
 
         $stores = $this->_helperConfig->getStores('lang');
@@ -337,7 +339,7 @@ class Import extends Factory
                     );
                     $this->_entities->setValues(
                         $this->getCode(),
-                        $connection->getTableName('catalog_category_entity'),
+                        $resource->getTable('catalog_category_entity'),
                         $values,
                         3,
                         $store['store_id']
@@ -352,12 +354,13 @@ class Import extends Factory
      */
     public function updateChildrenCount()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
 
         $connection->query('
-            UPDATE `' . $connection->getTableName('catalog_category_entity') . '` c SET `children_count` = (
+            UPDATE `' . $resource->getTable('catalog_category_entity') . '` c SET `children_count` = (
                 SELECT COUNT(`parent_id`) FROM (
-                    SELECT * FROM `' . $connection->getTableName('catalog_category_entity') . '`
+                    SELECT * FROM `' . $resource->getTable('catalog_category_entity') . '`
                 ) tmp
                 WHERE tmp.`path` LIKE CONCAT(c.`path`,\'/%\')
             )

--- a/Entities/Model/Entities.php
+++ b/Entities/Model/Entities.php
@@ -243,7 +243,7 @@ class Entities extends AbstractModel implements EntitiesInterface, IdentityInter
             $fragments[] = $tableSuffix;
         }
 
-        return $this->_getResource()->getConnection()->getTableName(join('_', $fragments));
+        return $this->_getResource()->getTable(join('_', $fragments));
     }
 
     /**

--- a/Entities/Model/ResourceModel/Entities.php
+++ b/Entities/Model/ResourceModel/Entities.php
@@ -292,8 +292,8 @@ class Entities extends AbstractDb
 
         $connection->delete($tableName, array($pimKey . ' = ?' => ''));
 
-        $pimgentoTable = $connection->getTableName('pimgento_entities');
-        $entityTable   = $connection->getTableName($entityTable);
+        $pimgentoTable = $this->getTable('pimgento_entities');
+        $entityTable   = $this->getTable($entityTable);
 
         if ($entityKey == 'entity_id') {
             $entityKey = $this->getColumnIdentifier($entityTable);
@@ -404,7 +404,7 @@ class Entities extends AbstractDb
 
                     $insert = $connection->insertFromSelect(
                         $select,
-                        $connection->getTableName($entityTable . '_' . $backendType),
+                        $this->getTable($entityTable . '_' . $backendType),
                         array('attribute_id', 'store_id', $identifier, 'value'),
                         $mode
                     );
@@ -418,7 +418,7 @@ class Entities extends AbstractDb
                             'value = ?' => '0000-00-00 00:00:00'
                         );
                         $connection->update(
-                            $connection->getTableName($entityTable . '_' . $backendType), $values, $where
+                            $this->getTable($entityTable . '_' . $backendType), $values, $where
                         );
                     }
                 }
@@ -463,7 +463,7 @@ class Entities extends AbstractDb
 
         $attribute = $connection->fetchRow(
             $connection->select()
-                ->from($connection->getTableName('eav_attribute'), array('attribute_id', 'backend_type'))
+                ->from($this->getTable('eav_attribute'), array('attribute_id', 'backend_type'))
                 ->where('entity_type_id = ?', $entityTypeId)
                 ->where('attribute_code = ?', $code)
                 ->limit(1)

--- a/Family/Model/Factory/Import.php
+++ b/Family/Model/Factory/Import.php
@@ -101,7 +101,8 @@ class Import extends Factory
      */
     public function insertFamily()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $values = array(
@@ -115,7 +116,7 @@ class Import extends Factory
 
         $connection->query(
             $connection->insertFromSelect(
-                $families, $connection->getTableName('eav_attribute_set'), array_keys($values), 1
+                $families, $resource->getTable('eav_attribute_set'), array_keys($values), 1
             )
         );
     }

--- a/Import/Helper/UrlRewrite.php
+++ b/Import/Helper/UrlRewrite.php
@@ -37,8 +37,9 @@ class UrlRewrite extends AbstractHelper
      */
     public function createUrlTmpTable()
     {
-        $connection   = $this->_entities->getResource()->getConnection();
-        $tableRewrite = $connection->getTableName('tmp_pimgento_rewrite');
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
+        $tableRewrite = $resource->getTable('tmp_pimgento_rewrite');
 
         $this->dropUrlRewriteTmpTable();
 
@@ -68,8 +69,9 @@ class UrlRewrite extends AbstractHelper
      */
     public function dropUrlRewriteTmpTable()
     {
-        $connection   = $this->_entities->getResource()->getConnection();
-        $tableRewrite = $connection->getTableName('tmp_pimgento_rewrite');
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
+        $tableRewrite = $resource->getTable('tmp_pimgento_rewrite');
 
         $connection->dropTable($tableRewrite);
     }
@@ -86,10 +88,11 @@ class UrlRewrite extends AbstractHelper
      */
     public function rewriteUrls($code, $storeId, $column, $urlSuffix)
     {
-        $connection         = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable           = $this->_entities->getTableName($code);
-        $tmpUrlRewriteTable = $connection->getTableName('tmp_pimgento_rewrite');
-        $urlRewriteTable    = $connection->getTableName('url_rewrite');
+        $tmpUrlRewriteTable = $resource->getTable('tmp_pimgento_rewrite');
+        $urlRewriteTable    = $resource->getTable('url_rewrite');
         $targetPathExpr     = new Expr('CONCAT("catalog/' . $code . '/view/id/", `_entity_id`)');
 
         // Fill temporary url table
@@ -168,9 +171,10 @@ class UrlRewrite extends AbstractHelper
      */
     protected function _cleanSystemUrlsBeforeInsertion($storeId)
     {
-        $connection         = $this->_entities->getResource()->getConnection();
-        $tmpUrlRewriteTable = $connection->getTableName('tmp_pimgento_rewrite');
-        $urlRewriteTable    = $connection->getTableName('url_rewrite');
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
+        $tmpUrlRewriteTable = $resource->getTable('tmp_pimgento_rewrite');
+        $urlRewriteTable    = $resource->getTable('url_rewrite');
 
         $select = $connection->select()
             ->from(
@@ -222,8 +226,9 @@ class UrlRewrite extends AbstractHelper
      */
     protected function _insertInUrlRewriteTable($select, $columns, $insertionType)
     {
-        $connection      = $this->_entities->getResource()->getConnection();
-        $urlRewriteTable = $connection->getTableName('url_rewrite');
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
+        $urlRewriteTable = $resource->getTable('url_rewrite');
 
         $connection->query(
             $connection->insertFromSelect(

--- a/Option/Model/Factory/Import.php
+++ b/Option/Model/Factory/Import.php
@@ -93,7 +93,8 @@ class Import extends Factory
      */
     public function insertOptions()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $columns = array(
@@ -107,7 +108,7 @@ class Import extends Factory
         $options = $connection->select()
             ->from(array('a' => $tmpTable), $columns)
             ->joinInner(
-                array('b' => $connection->getTableName('pimgento_entities')),
+                array('b' => $resource->getTable('pimgento_entities')),
                 'a.attribute = b.code AND b.import = "attribute"',
                 array(
                     'attribute_id' => 'b.entity_id'
@@ -117,7 +118,7 @@ class Import extends Factory
         $connection->query(
             $connection->insertFromSelect(
                 $options,
-                $connection->getTableName('eav_attribute_option'),
+                $resource->getTable('eav_attribute_option'),
                 array('option_id', 'sort_order', 'attribute_id'),
                 1
             )
@@ -129,7 +130,8 @@ class Import extends Factory
      */
     public function insertValues()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $stores = $this->_helperConfig->getStores('lang');
@@ -150,7 +152,7 @@ class Import extends Factory
                     $connection->query(
                         $connection->insertFromSelect(
                             $options,
-                            $connection->getTableName('eav_attribute_option_value'),
+                            $resource->getTable('eav_attribute_option_value'),
                             array('option_id', 'store_id', 'value'),
                             1
                         )

--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -222,7 +222,8 @@ class Import extends Factory
      */
     public function createConfigurable()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         if (!$this->moduleIsEnabled('Pimgento_Variant')) {
@@ -294,7 +295,7 @@ class Import extends Factory
 
                             if ($connection->tableColumnExists($tmpTable, $column)) {
                                 if (!strlen($value)) {
-                                    if ($connection->tableColumnExists($connection->getTableName('pimgento_variant'), $column)) {
+                                    if ($connection->tableColumnExists($resource->getTable('pimgento_variant'), $column)) {
                                         $data[$column] = 'v.' . $column;
                                     } else {
                                         $data[$column] = 'e.' . $column;
@@ -312,7 +313,7 @@ class Import extends Factory
             $configurable = $connection->select()
                 ->from(array('e' => $tmpTable), $data)
                 ->joinInner(
-                    array('v' => $connection->getTableName('pimgento_variant')),
+                    array('v' => $resource->getTable('pimgento_variant')),
                     'e.groups = v.code',
                     array()
                 )
@@ -338,7 +339,8 @@ class Import extends Factory
      */
     public function updateAttributeSetId()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         if (!$connection->tableColumnExists($tmpTable, 'family')) {
@@ -350,7 +352,7 @@ class Import extends Factory
             $families = $connection->select()
                 ->from(false, array('_attribute_set_id' => 'c.entity_id'))
                 ->joinLeft(
-                    array('c' => $connection->getTableName('pimgento_entities')),
+                    array('c' => $resource->getTable('pimgento_entities')),
                     'p.family = c.code AND c.import = "family"',
                     array()
                 );
@@ -385,7 +387,8 @@ class Import extends Factory
      */
     public function updateOption()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $columns = array_keys($connection->describeTable($tmpTable));
@@ -429,7 +432,7 @@ class Import extends Factory
                 // Sub select to increase performance versus FIND_IN_SET
                 $subSelect = $connection->select()
                     ->from(
-                        array('c' => $connection->getTableName('pimgento_entities')),
+                        array('c' => $resource->getTable('pimgento_entities')),
                         array('code' => 'SUBSTRING(`c`.`code`,' . $prefixL . ')', 'entity_id' => 'c.entity_id')
                     )
                     ->where("c.code like '".$columnPrefix."_%' ")
@@ -472,17 +475,18 @@ class Import extends Factory
      */
     public function createEntities()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
-        if ($connection->isTableExists($connection->getTableName('sequence_product'))) {
+        if ($connection->isTableExists($resource->getTable('sequence_product'))) {
             $values = array(
                 'sequence_value' => '_entity_id',
             );
             $parents = $connection->select()->from($tmpTable, $values);
             $connection->query(
                 $connection->insertFromSelect(
-                    $parents, $connection->getTableName('sequence_product'), array_keys($values), 1
+                    $parents, $resource->getTable('sequence_product'), array_keys($values), 1
                 )
             );
         }
@@ -497,7 +501,7 @@ class Import extends Factory
             'updated_at'       => new Expr('now()'),
         );
 
-        $table = $connection->getTableName('catalog_product_entity');
+        $table = $resource->getTable('catalog_product_entity');
 
         $columnIdentifier = $this->_entities->getColumnIdentifier($table);
 
@@ -531,7 +535,8 @@ class Import extends Factory
      */
     public function setValues()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $stores = array_merge(
@@ -612,7 +617,7 @@ class Import extends Factory
 
         foreach($values as $storeId => $data) {
             $this->_entities->setValues(
-                $this->getCode(), $connection->getTableName('catalog_product_entity'), $data, 4, $storeId, 1
+                $this->getCode(), $resource->getTable('catalog_product_entity'), $data, 4, $storeId, 1
             );
         }
     }
@@ -622,7 +627,8 @@ class Import extends Factory
      */
     public function linkConfigurable()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         if (!$this->moduleIsEnabled('Pimgento_Variant')) {
@@ -669,7 +675,7 @@ class Import extends Factory
 
                     $hasOptions = $connection->fetchOne(
                         $connection->select()
-                            ->from($connection->getTableName('eav_attribute_option'), array(new Expr(1)))
+                            ->from($resource->getTable('eav_attribute_option'), array(new Expr(1)))
                             ->where('attribute_id = ?', $id)
                             ->limit(1)
                     );
@@ -685,13 +691,13 @@ class Import extends Factory
                         'position' => $position++,
                     );
                     $connection->insertOnDuplicate(
-                        $connection->getTableName('catalog_product_super_attribute'), $values, array()
+                        $resource->getTable('catalog_product_super_attribute'), $values, array()
                     );
 
                     /* catalog_product_super_attribute_label */
                     $superAttributeId = $connection->fetchOne(
                         $connection->select()
-                            ->from($connection->getTableName('catalog_product_super_attribute'))
+                            ->from($resource->getTable('catalog_product_super_attribute'))
                             ->where('attribute_id = ?', $id)
                             ->where('product_id = ?', $row['_entity_id'])
                             ->limit(1)
@@ -713,7 +719,7 @@ class Import extends Factory
                         $childId = $connection->fetchOne(
                             $connection->select()
                                 ->from(
-                                    $connection->getTableName('catalog_product_entity'),
+                                    $resource->getTable('catalog_product_entity'),
                                     array(
                                         'entity_id'
                                     )
@@ -740,18 +746,18 @@ class Import extends Factory
 
                     if (count($valuesSuperLink)  > $stepSize) {
                         $connection->insertOnDuplicate(
-                            $connection->getTableName('catalog_product_super_attribute_label'),
+                            $resource->getTable('catalog_product_super_attribute_label'),
                             $valuesLabels,
                             array()
                         );
 
                         $connection->insertOnDuplicate(
-                            $connection->getTableName('catalog_product_relation'),
+                            $resource->getTable('catalog_product_relation'),
                             $valuesRelations,
                             array()
                         );
                         $connection->insertOnDuplicate(
-                            $connection->getTableName('catalog_product_super_link'),
+                            $resource->getTable('catalog_product_super_link'),
                             $valuesSuperLink,
                             array()
                         );
@@ -766,18 +772,18 @@ class Import extends Factory
 
             if (count($valuesSuperLink)  > 0) {
                 $connection->insertOnDuplicate(
-                    $connection->getTableName('catalog_product_super_attribute_label'),
+                    $resource->getTable('catalog_product_super_attribute_label'),
                     $valuesLabels,
                     array()
                 );
 
                 $connection->insertOnDuplicate(
-                    $connection->getTableName('catalog_product_relation'),
+                    $resource->getTable('catalog_product_relation'),
                     $valuesRelations,
                     array()
                 );
                 $connection->insertOnDuplicate(
-                    $connection->getTableName('catalog_product_super_link'),
+                    $resource->getTable('catalog_product_super_link'),
                     $valuesSuperLink,
                     array()
                 );
@@ -790,7 +796,8 @@ class Import extends Factory
      */
     public function setWebsites()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $websites = $this->_helperConfig->getStores('website_id');
@@ -810,7 +817,7 @@ class Import extends Factory
                 );
             $connection->query(
                 $connection->insertFromSelect(
-                    $select, $connection->getTableName('catalog_product_website'), array('product_id', 'website_id'), 1
+                    $select, $resource->getTable('catalog_product_website'), array('product_id', 'website_id'), 1
                 )
             );
         }
@@ -821,7 +828,8 @@ class Import extends Factory
      */
     public function setCategories()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         if (!$connection->tableColumnExists($tmpTable, 'categories')) {
@@ -834,7 +842,7 @@ class Import extends Factory
             $select = $connection->select()
                 ->from(
                     array(
-                        'c' => $connection->getTableName('pimgento_entities')
+                        'c' => $resource->getTable('pimgento_entities')
                     ),
                     array()
                 )
@@ -847,7 +855,7 @@ class Import extends Factory
                     )
                 )
                 ->joinInner(
-                    array('e' => $connection->getTableName('catalog_category_entity')),
+                    array('e' => $resource->getTable('catalog_category_entity')),
                     'c.entity_id = e.entity_id',
                     array()
                 );
@@ -855,7 +863,7 @@ class Import extends Factory
             $connection->query(
                 $connection->insertFromSelect(
                     $select,
-                    $connection->getTableName('catalog_category_product'),
+                    $resource->getTable('catalog_category_product'),
                     array('category_id', 'product_id'),
                     1
                 )
@@ -869,7 +877,8 @@ class Import extends Factory
      */
     public function initStock()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $websiteId = $this->_helperConfig->getDefaultScopeId();
@@ -889,7 +898,7 @@ class Import extends Factory
         $connection->query(
             $connection->insertFromSelect(
                 $select,
-                $connection->getTableName('cataloginventory_stock_item'),
+                $resource->getTable('cataloginventory_stock_item'),
                 array_keys($values),
                 AdapterInterface::INSERT_IGNORE
             )
@@ -901,7 +910,8 @@ class Import extends Factory
      */
     public function setUrlRewrite()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $stores = array_merge(
@@ -946,7 +956,7 @@ class Import extends Factory
 
                     $this->_entities->setValues(
                         $this->getCode(),
-                        $connection->getTableName('catalog_product_entity'),
+                        $resource->getTable('catalog_product_entity'),
                         ['url_key' => $column],
                         4,
                         $store['store_id'],

--- a/Product/Model/Factory/Import/Media.php
+++ b/Product/Model/Factory/Import/Media.php
@@ -359,7 +359,8 @@ class Media extends Factory
      */
     public function mediaUpdateDataBase()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tableMedia = $this->_entities->getTableName('media');
         $step = 5000;
 
@@ -377,19 +378,19 @@ class Media extends Factory
             ->where('t.attribute_id is not null');
 
         $identifier = $this->_entities->getColumnIdentifier(
-            $connection->getTableName('catalog_product_entity_varchar')
+            $resource->getTable('catalog_product_entity_varchar')
         );
 
         $query = $connection->insertFromSelect(
             $select,
-            $connection->getTableName('catalog_product_entity_varchar'),
+            $resource->getTable('catalog_product_entity_varchar'),
             ['attribute_id', 'store_id', $identifier, 'value'],
             AdapterInterface::INSERT_ON_DUPLICATE
         );
         $connection->query($query);
 
         // working on "media gallery"
-        $tableGallery = $connection->getTableName('catalog_product_entity_media_gallery');
+        $tableGallery = $resource->getTable('catalog_product_entity_media_gallery');
 
         // get the value id from gallery (for already existing medias)
         $maxId = $this->mediaGetMaxId($tableGallery, 'value_id');
@@ -445,7 +446,7 @@ class Media extends Factory
         }
 
         // working on "media gallery value"
-        $tableGallery = $connection->getTableName('catalog_product_entity_media_gallery_value');
+        $tableGallery = $resource->getTable('catalog_product_entity_media_gallery_value');
 
         $identifier = $this->_entities->getColumnIdentifier($tableGallery);
 
@@ -489,7 +490,7 @@ class Media extends Factory
         $connection->query($query);
 
         // working on "media gallery value to entity"
-        $tableGallery = $connection->getTableName('catalog_product_entity_media_gallery_value_to_entity');
+        $tableGallery = $resource->getTable('catalog_product_entity_media_gallery_value_to_entity');
 
         $identifier = $this->_entities->getColumnIdentifier($tableGallery);
 

--- a/Product/Model/Factory/Import/Related.php
+++ b/Product/Model/Factory/Import/Related.php
@@ -101,12 +101,13 @@ class Related extends Factory
      */
     public function relatedImportColumn($type)
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
 
         $tmpTable     = $this->_entities->getTableName($this->getCode());
         $tableNumber  = $this->_entities->getTableName('numbers');;
         $tableRelated = $this->_entities->getTableName('related');;
-        $tableProduct = $connection->getTableName('catalog_product_entity');
+        $tableProduct = $resource->getTable('catalog_product_entity');
 
         $column = $type['column'];
 
@@ -191,7 +192,7 @@ class Related extends Factory
             );
         $query = $connection->insertFromSelect(
             $select,
-            $connection->getTableName('catalog_product_link'),
+            $resource->getTable('catalog_product_link'),
             ['product_id', 'linked_product_id', 'link_type_id'],
             AdapterInterface::INSERT_ON_DUPLICATE
         );

--- a/Variant/Model/Factory/Import.php
+++ b/Variant/Model/Factory/Import.php
@@ -85,11 +85,12 @@ class Import extends Factory
      */
     public function removeColumns()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
 
         $except = array('code', 'axis');
 
-        $variantTable = $connection->getTableName('pimgento_variant');
+        $variantTable = $resource->getTable('pimgento_variant');
 
         $columns = array_keys($connection->describeTable($variantTable));
 
@@ -107,12 +108,13 @@ class Import extends Factory
      */
     public function addColumns()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
         $except = array('code', 'axis', 'type', '_entity_id', '_is_new');
 
-        $variantTable = $connection->getTableName('pimgento_variant');
+        $variantTable = $resource->getTable('pimgento_variant');
 
         $columns = array_keys($connection->describeTable($tmpTable));
 
@@ -130,10 +132,11 @@ class Import extends Factory
      */
     public function updateData()
     {
-        $connection = $this->_entities->getResource()->getConnection();
+        $resource = $this->_entities->getResource();
+        $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
 
-        $variantTable = $connection->getTableName('pimgento_variant');
+        $variantTable = $resource->getTable('pimgento_variant');
 
         $variant = $connection->query(
             $connection->select()->from($tmpTable)
@@ -141,7 +144,7 @@ class Import extends Factory
 
         $attributes = $connection->fetchPairs(
             $connection->select()->from(
-                $connection->getTableName('eav_attribute'), array('attribute_code', 'attribute_id')
+                $resource->getTable('eav_attribute'), array('attribute_code', 'attribute_id')
             )
             ->where('entity_type_id = ?', 4)
         );


### PR DESCRIPTION
Fix issues with table prefixes.

Using Connection->getTableName does not add prefixes to the tables and will fail.