### PR TITLE
use default locale for family import

### DIFF
--- a/Family/Model/Factory/Import.php
+++ b/Family/Model/Factory/Import.php
@@ -70,7 +70,8 @@ class Import extends Factory
             $this->setStatus(false);
             $this->setMessage($this->getFileNotFoundErrorMessage());
         } else {
-            $this->_entities->createTmpTableFromFile($file, $this->getCode(), array('code', 'label'));
+            $label = 'label-' . $this->_helperConfig->getDefaultLocale();
+            $this->_entities->createTmpTableFromFile($file, $this->getCode(), array('code', $label));
         }
     }
 
@@ -104,11 +105,12 @@ class Import extends Factory
         $resource = $this->_entities->getResource();
         $connection = $resource->getConnection();
         $tmpTable = $this->_entities->getTableName($this->getCode());
+        $label = 'label-' . $this->_helperConfig->getDefaultLocale();
 
         $values = array(
             'attribute_set_id'   => '_entity_id',
             'entity_type_id'     => new Expr(4),
-            'attribute_set_name' => new Expr('CONCAT("Pim", " ", `label`)'),
+            'attribute_set_name' => new Expr('CONCAT("Pim", " ", `' . $label . '`)'),
             'sort_order'         => new Expr(1),
         );
 

--- a/Import/Helper/Config.php
+++ b/Import/Helper/Config.php
@@ -2,6 +2,7 @@
 
 namespace Pimgento\Import\Helper;
 
+use \Magento\Directory\Helper\Data;
 use \Magento\Framework\App\Filesystem\DirectoryList;
 use \Magento\Framework\App\Helper\AbstractHelper;
 use \Magento\Framework\App\Helper\Context;
@@ -188,5 +189,13 @@ class Config extends AbstractHelper
     public function getDefaultScopeId()
     {
         return $this->catalogInventoryConfiguration->getDefaultScopeId();
+    }
+
+    public function getDefaultLocale()
+    {
+        return $this->scopeConfig->getValue(
+            Data::XML_PATH_DEFAULT_LOCALE,
+            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+        );
     }
 }

--- a/Import/Helper/Config.php
+++ b/Import/Helper/Config.php
@@ -195,7 +195,7 @@ class Config extends AbstractHelper
     {
         return $this->scopeConfig->getValue(
             Data::XML_PATH_DEFAULT_LOCALE,
-            \Magento\Store\Model\ScopeInterface::SCOPE_STORE
+            ScopeInterface::SCOPE_STORE
         );
     }
 }


### PR DESCRIPTION
Fixes #126: To be able to use the native "akeneo_csv_export" of the "Akeneo CSV Connector" instead of using the "EnhancedConnectorBundle" it is necessary to set the default locale to get the correct translation of the label from the CSV file.