### PR TITLE
remove product from old categories

### DIFF
--- a/Product/Model/Factory/Import.php
+++ b/Product/Model/Factory/Import.php
@@ -869,6 +869,30 @@ class Import extends Factory
                 )
             );
 
+            //Remove product from old categories
+            $selectToDelete = $connection->select()
+                ->from(
+                    array(
+                        'c' => $resource->getTable('pimgento_entities')
+                    ),
+                    array()
+                )
+                ->joinInner(
+                    array('p' => $tmpTable),
+                    '!FIND_IN_SET(`c`.`code`, `p`.`categories`) AND `c`.`import` = "category"',
+                    array(
+                        'category_id' => 'c.entity_id',
+                        'product_id'  => 'p._entity_id'
+                    )
+                )
+                ->joinInner(
+                    array('e' => $resource->getTable('catalog_category_entity')),
+                    'c.entity_id = e.entity_id',
+                    array()
+                );
+
+            $connection->delete($resource->getTable('catalog_category_product'),
+                '(category_id, product_id) IN (' . $selectToDelete->assemble() . ')');
         }
     }
 
@@ -947,7 +971,7 @@ class Import extends Factory
                         );
                     }
                 }
-                
+
                 foreach ($affected as $store) {
 
                     if ($store['store_id'] == 0) {


### PR DESCRIPTION
Fixes #112: To have the correct categories at the product, old categories has to be removed. I adapted the part of the function from PIMGento for Magento 1.