### PR TITLE
Use option code as admin value instead of label.

### DIFF
--- a/Option/Model/Factory/Import.php
+++ b/Option/Model/Factory/Import.php
@@ -145,7 +145,7 @@ class Import extends Factory
                             array(
                                 'option_id' => '_entity_id',
                                 'store_id'  => new Expr($store['store_id']),
-                                'value'     => 'label-' . $local
+                                'value'     => $store['store_id'] == 0 ? 'code' : 'label-' . $local
                             )
                         );
 


### PR DESCRIPTION
This prevents duplicates of the admin value if two options have the same label name.