### PR TITLE
Solve problem when an attribute is attached to a lot of families

### DIFF
--- a/Attribute/Model/Factory/Import.php
+++ b/Attribute/Model/Factory/Import.php
@@ -186,7 +186,7 @@ class Import extends Factory
         $tmpTable = $this->_entities->getTableName($this->getCode());
         $familyAttributeRelationsTable = 'pimgento_family_attribute_relations';
 
-        $connection->addColumn($tmpTable, '_attribute_set_id', 'VARCHAR(255) NULL');
+        $connection->addColumn($tmpTable, '_attribute_set_id', 'TEXT NULL');
 
         $importTmpTable = $connection->select()->from($tmpTable, array('code', '_entity_id'));
         $queryTmpTable = $connection->query($importTmpTable);


### PR DESCRIPTION
I had some attributes attached to more than 500 families (attribute sets) which ids concatenated were longer than 255 characters. Now the limitation is removed.