### PR TITLE
Hotfix - Import:insertValues for Options

### DIFF
--- a/Option/Model/Factory/Import.php
+++ b/Option/Model/Factory/Import.php
@@ -141,12 +141,16 @@ class Import extends Factory
                 foreach ($data as $store) {
                     $options = $connection->select()
                         ->from(
-                            $tmpTable,
+                            array('a' => $tmpTable),
                             array(
                                 'option_id' => '_entity_id',
                                 'store_id'  => new Expr($store['store_id']),
                                 'value'     => 'label-' . $local
                             )
+                        )->joinInner(
+                            array('b' => $resource->getTable('pimgento_entities')),
+                            'a.attribute = b.code AND b.import = "attribute"',
+                            array()
                         );
 
                     $connection->query(


### PR DESCRIPTION
- this code fix adds conditions to insert options
for existing attributes only in magento
- before this fix: inserting options for non existing
attribute creates a mysql error and the whole import
stops