### PR TITLE
Improved image import performance (on update)

### DIFF
--- a/Product/Helper/Media.php
+++ b/Product/Helper/Media.php
@@ -246,8 +246,8 @@ class Media extends AbstractHelper
      */
     public function deleteMediaFile($filePath)
     {
-        if (file_exists($filePath)) {
-            $absolutePath = rtrim($this->getMediaAbsolutePath(), '/').'/'.ltrim($filePath, '/');
+        $absolutePath = rtrim($this->directoryList->getPath('media'), '/').'/'.ltrim($filePath, '/');
+        if (file_exists($absolutePath)) {
             unlink($absolutePath);
         }
     }

--- a/Product/Helper/Media.php
+++ b/Product/Helper/Media.php
@@ -239,6 +239,20 @@ class Media extends AbstractHelper
     }
 
     /**
+     * Delete a file inside the Media folder
+     * Path should be relative to the media folder
+     *
+     * @param string $filePath
+     */
+    public function deleteMediaFile($filePath)
+    {
+        if (file_exists($filePath)) {
+            $absolutePath = rtrim($this->getMediaAbsolutePath(), '/').'/'.ltrim($filePath, '/');
+            unlink($absolutePath);
+        }
+    }
+
+    /**
      * Generate a list of resize types, that may be used for cache invalidation
      *
      * @return array
@@ -254,7 +268,7 @@ class Media extends AbstractHelper
             if (empty($themes)) {
                 foreach ($this->getFrontendModules() as $module) {
                     $this->imageResizeTypes = array_merge($this->imageResizeTypes, $this->viewConfig->getViewConfig([
-                        'area'  => 'frontend'
+                        'area' => 'frontend',
                     ])->getMediaEntities($module, 'images'));
                 }
             }

--- a/Product/Model/Factory/Import/Media.php
+++ b/Product/Model/Factory/Import/Media.php
@@ -328,6 +328,7 @@ class Media extends Factory
             foreach ($medias as $media) {
                 $from = $this->_mediaHelper->getImportFolder() . $media['from'];
                 $to = $this->_mediaHelper->getMediaAbsolutePath() . $media['to'];
+                $cleanCache = false;
 
                 // if it does not exist, we pass
                 if (!is_file($from)) {
@@ -341,13 +342,19 @@ class Media extends Factory
 
                 // remove the file if it exist
                 if (is_file($to)) {
+                    if (md5_file($from) !== md5_file($to)) {
+                        $cleanCache = true;
+                    }
                     unlink($to);
                 }
 
                 copy($from, $to);
 
-                $this->image->setBaseFile($media['to']);
-                $this->image->saveFile();
+                // clean the cache only if we need to
+                if($cleanCache) {
+                    $this->image->setBaseFile($media['to']);
+                    $this->image->saveFile();
+                }
             }
         }
     }

--- a/Product/Model/Factory/Import/Media.php
+++ b/Product/Model/Factory/Import/Media.php
@@ -406,7 +406,8 @@ class Media extends Factory
             }
 
             $this->image->setBaseFile($imageFile);
-            $this->image->saveFile();
+            $imagePath = $this->image->getNewFile();
+            $this->_mediaHelper->deleteMediaFile($imagePath);
         }
     }
 


### PR DESCRIPTION
Test case:
* I have a Magento with ~30 stores, 2k products, and about 6 image per product
* The product imports are split in groups of 3 stores, due to issue similar to #97
* Reproduced on a Magento 2.1.10, Pimgento 100.2.23

Result:
* Only tested one import, and stopped it after one hour... with a small math, it may have taken about 2h
* It's unsuitable for production : daily imports would take about 20h !

Cause:
* The image cache is cleaned for every image import ; but we only need to clear it on updates