### PR TITLE
Ensure attribute order is updated in family.

### DIFF
--- a/Attribute/Model/Factory/Import.php
+++ b/Attribute/Model/Factory/Import.php
@@ -325,7 +325,7 @@ class Import extends Factory
                 $row['_entity_id'],
                 $data,
                 null,
-                0
+                $row['sort_order']
             );
 
             /* Add Attribute to group and family */


### PR DESCRIPTION
(Now the order is constantly reset, meaning you can't set an order manually in Magento)
Fixes: #176