### PR TITLE
Change DB type for temp tables to INNODB to prevent table crashes

### DIFF
--- a/Entities/Model/ResourceModel/Entities.php
+++ b/Entities/Model/ResourceModel/Entities.php
@@ -152,7 +152,7 @@ class Entities extends AbstractDb
             'Is New'
         );
 
-        $table->setOption('type', 'MYISAM');
+        $table->setOption('type', 'INNODB');
 
         $connection->createTable($table);
 
@@ -375,7 +375,7 @@ class Entities extends AbstractDb
     public function setValues($tableName, $entityTable, $values, $entityTypeId, $storeId, $mode = 1)
     {
         $connection = $this->getConnection();
-        
+
         foreach ($values as $code => $value) {
             if (($attribute = $this->getAttribute($code, $entityTypeId))) {
                 if ($attribute['backend_type'] !== 'static') {

--- a/Entities/Model/ResourceModel/Entities.php
+++ b/Entities/Model/ResourceModel/Entities.php
@@ -471,7 +471,7 @@ class Entities extends AbstractDb
                 ->where('attribute_code = ?', $code)
                 ->limit(1)
         );
-        return count($attribute) ? $attribute : false;
+        return is_array($attribute) ? count($attribute) ? $attribute : false : false ;
     }
 
     /**


### PR DESCRIPTION
I had a problem where during the product import the temporary tables were crashing and the products were not imported. Changing the table type to INNODB solved this.